### PR TITLE
Run locale_gen only on debian based linuxes

### DIFF
--- a/nova/core/roles/os_configuration/tasks/linux.yml
+++ b/nova/core/roles/os_configuration/tasks/linux.yml
@@ -19,6 +19,7 @@
   community.general.locale_gen:
     name: en_US.UTF-8
     state: present
+  when: ansible_os_family != 'RedHat'
 
 - name: Setting the default locale...
   ansible.builtin.command: localectl set-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8


### PR DESCRIPTION
RedHat derived distros do not have locale-gen tool
