### PR TITLE
Define the src URL for the roles inside `requirements.yml`

### DIFF
--- a/nova/core/requirements/requirements.yml
+++ b/nova/core/requirements/requirements.yml
@@ -1,16 +1,22 @@
 ---
 roles:
   - name: geerlingguy.apache
+    src: https://github.com/geerlingguy/ansible-role-apache.git
     version: 3.3.0
   - name: geerlingguy.composer
+    src: https://github.com/geerlingguy/ansible-role-composer.git
     version: 1.9.2
   - name: geerlingguy.mysql
+    src: https://github.com/geerlingguy/ansible-role-mysql.git
     version: 4.3.3
   - name: geerlingguy.php
+    src: https://github.com/geerlingguy/ansible-role-php.git
     version: 5.0.1
   - name: geerlingguy.php-versions
+    src: https://github.com/geerlingguy/ansible-role-php-versions.git
     version: 6.0.1
   - name: geerlingguy.postgresql
+    src: https://github.com/geerlingguy/ansible-role-postgresql.git
     version: 3.5.0
 
 collections:


### PR DESCRIPTION
Implement workaround to save the broken galaxy when installing roles
https://www.jeffgeerling.com/blog/2023/ansible-galaxy-error-unable-compare-role-versions



