### PR TITLE
added local_vm_folder check/create

### DIFF
--- a/nova/core/roles/machine_operations/tasks/vmware_workstation/create.yml
+++ b/nova/core/roles/machine_operations/tasks/vmware_workstation/create.yml
@@ -51,6 +51,12 @@
           ansible.builtin.set_fact:
             fresh_deploy: true
 
+        - name: Create VM folder if it does not exist
+          ansible.builtin.file:
+            path: "{{ local_vm_folder }}"
+            state: directory
+            recurse: true
+
         - name: Creating {{ custom_vm_name | default(vm_name) }} from {{ vm_template }}...
           ansible.builtin.shell: ovftool -tt=vmx -n={{ custom_vm_name | default(vm_name) }} {{ local_vmx_template_path }} {{ local_vm_folder }}
 


### PR DESCRIPTION
This simple change allows users to define any `local_vm_folder` and `local_vmx_path` variable

when used like this in `zone_vmware_workstation.yml`:
```
local_vmx_path: /home/{{ lookup('env', 'USER') }}/vmware/{{project_fullname}}/{{ custom_vm_name | default(vm_name) }}/{{ custom_vm_name | default(vm_name) }}.vmx
local_vm_folder: /home/{{ lookup('env', 'USER') }}/vmware/{{project_fullname}}/
```
it allows project based VM hierarchy in VMWare workstation after scanning for VMs
![image](https://github.com/novateams/nova.core/assets/2199889/c9dee2af-f8b2-478d-8d9c-60a29e34b401)
if "Keep the hierarchy of folder in library" is checked
![image](https://github.com/novateams/nova.core/assets/2199889/19cfde6b-a860-4913-a90f-2b2d1030366e)

