### PR TITLE
v1.0.15

### DIFF
--- a/nova/core/roles/accounts/defaults/main.yml
+++ b/nova/core/roles/accounts/defaults/main.yml
@@ -44,5 +44,4 @@ unix_distro_skel_map:
   FreeBSD: /usr/share/skel
 
 unix_distro_sudoers_map:
-  Archlinux: /etc/sudoers.d/10-installer
   FreeBSD: /usr/local/etc/sudoers


### PR DESCRIPTION
Modify accounts role. Removed variable for Arch linux. Arch template now uses wheel group for administrators. Deployment tested in vCenter.