### PR TITLE
v1.0.20

### DIFF
--- a/nova/core/roles/linux_xrdp_server/tasks/debian.yml
+++ b/nova/core/roles/linux_xrdp_server/tasks/debian.yml
@@ -1,7 +1,9 @@
 ---
 - name: Installing xrdp...
   ansible.builtin.package:
-    name: xrdp
+    name:
+      - xrdp
+      - xorgxrdp
     state: present
     update_cache: true
   register: xrdp_install


### PR DESCRIPTION
Bring `xorgxrdp` packet back to `linux_xrdp_server` role as kali OS needs it