### PR TITLE
fixed var templating for caddy_container_ports

### DIFF
--- a/nova/core/roles/caddy/tasks/install.yml
+++ b/nova/core/roles/caddy/tasks/install.yml
@@ -31,7 +31,7 @@
 
 - name: Templating Caddy configuration files for {{ inventory_hostname }}...
   ansible.builtin.template:
-    src: caddy.yml
+    src: caddy.yml.j2
     dest: "{{ caddy_config_folder }}/docker-compose.yml"
     mode: "0644"
     lstrip_blocks: true

--- a/nova/core/roles/caddy/templates/caddy.yml.j2
+++ b/nova/core/roles/caddy/templates/caddy.yml.j2
@@ -5,13 +5,13 @@ services:
     hostname: caddy
     container_name: caddy
     restart: unless-stopped
-    ports: "{{ caddy_container_ports }}"
+    ports: {{ caddy_container_ports }}
     volumes:
       - /srv/caddy/etc:/etc/caddy # When only mounting Caddyfile the changes are not picked up inside the container
       - /srv/caddy/data:/data/caddy
       - /srv/caddy/config:/config/caddy
       - /srv/caddy/logs:/srv/logs
-      - "{{ caddy_certificates_folder }}:/srv/certs"
+      - {{ caddy_certificates_folder }}:/srv/certs
       - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt
 
 networks:


### PR DESCRIPTION
The caddy role seems to be broken right now, the container ports are templated into a string.
