### PR TITLE
Add retries in regenerate machine ID task for linux in `os_configuration`

### DIFF
--- a/nova/core/roles/os_configuration/tasks/linux.yml
+++ b/nova/core/roles/os_configuration/tasks/linux.yml
@@ -90,6 +90,8 @@
     executable: /bin/bash
   register: regenerate_machine_id
   changed_when: regenerate_machine_id.stdout != "done"
+  retries: 5
+  delay: 3
 
 - name: Restart systemd-journald... # This required for journalctl to work properly after machine-id regeneration
   ansible.builtin.systemd:


### PR DESCRIPTION
To avoid errors in slow systems like: 

rm: cannot remove ''/etc/machine-id'': Device or resource busy