### PR TITLE
Fix the group name for administrators.

### DIFF
--- a/nova/core/galaxy.yml
+++ b/nova/core/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: nova
 name: core
-version: 3.4.36
+version: 3.4.37
 readme: README.md
 authors:
   - https://github.com/novateams

--- a/nova/core/roles/accounts/tasks/opnsense.yml
+++ b/nova/core/roles/accounts/tasks/opnsense.yml
@@ -103,7 +103,7 @@
     dest: /conf/config.xml
     mode: "0644"
     owner: root
-    group: admins
+    group: wheel
 
 - name: Removing local config.xml file...
   ansible.builtin.file:


### PR DESCRIPTION
Tested with OPNsense versions 21.1 and 24.7