### PR TITLE
Add backwards compatibility for networkd customization for vSphere 7

### DIFF
--- a/nova/core/roles/configure_networking/defaults/main.yml
+++ b/nova/core/roles/configure_networking/defaults/main.yml
@@ -46,3 +46,5 @@ extra_routes: [] # Configure extra routes per interfaces.
 configure_networking_panos_enable_ipv6: true # Enable IPv6 on configured interfaces
 configure_networking_panos_primary_dns_server: "{{ dns_servers[0] }}"
 configure_networking_panos_secondary_dns_server: "{{ dns_servers6[0] }}"
+
+vsphere_version: 8

--- a/nova/core/roles/configure_networking/tasks/vsphere/networkd.yml
+++ b/nova/core/roles/configure_networking/tasks/vsphere/networkd.yml
@@ -7,7 +7,7 @@
 
 - name: Determining OS...
   ansible.builtin.set_fact:
-    network_customization_os: "{{ 'debian' if ansible_os_family == 'Debian' else 'arch' if ansible_os_family == 'ArchLinux' }}"
+    network_customization_os: "{{ 'debian' if customization_method_distribution == 'Debian' else 'arch' if customization_method_distribution == 'ArchLinux' }}"
   when: vsphere_version == 7
 
 - name: Determining OS...

--- a/nova/core/roles/configure_networking/tasks/vsphere/networkd.yml
+++ b/nova/core/roles/configure_networking/tasks/vsphere/networkd.yml
@@ -3,13 +3,24 @@
 - name: Setting OS as fact...
   ansible.builtin.set_fact:
     configure_networking_os: "{{ (vmware_tools_information.instance.advanced_settings['guestInfo.detailed.data']).split('prettyName=')[1] }}"
+  when: vsphere_version == 8
+
+- name: Determining OS...
+  ansible.builtin.set_fact:
+    network_customization_os: "{{ 'debian' if ansible_os_family == 'Debian' else 'arch' if ansible_os_family == 'ArchLinux' }}"
+  when: vsphere_version == 7
+
+- name: Determining OS...
+  ansible.builtin.set_fact:
+    network_customization_os: "{{ 'debian' if configure_networking_os is search('Debian') else 'arch' if configure_networking_os is search('Arch') }}"
+  when: vsphere_version == 8
 
 - name: Including networkd configuration tasks...
   become: false
   delegate_to: localhost
   block:
     - name: Cleaning up Debian...
-      when: configure_networking_os is search('Debian')
+      when: network_customization_os == 'debian'
       block:
         - name: Masking NetworkManager service and cleaning previous networkd configuration on Debian...
           ansible.builtin.uri:
@@ -214,7 +225,7 @@
         validate_certs: "{{ validate_vmware_certs }}"
 
     - name: Applying network configuration on Debian...
-      when: configure_networking_os is search('Debian')
+      when: network_customization_os == 'debian'
       block:
         - name: Configuring network interface(s) names on Debian...
           ansible.builtin.uri:
@@ -237,7 +248,7 @@
           ansible.builtin.include_tasks: command_run_check.yml
 
     - name: Applying network configuration on Debian...
-      when: configure_networking_os is search('Arch')
+      when: network_customization_os == 'arch'
       block:
         - name: Configuring network interface(s) names on Arch...
           ansible.builtin.uri:


### PR DESCRIPTION
`guestInfo.detailed.data` is not available in vSphere 7, fall back to using `customization_method_distribution` variable in case `vsphere_version` is configured as "7". Defaults to 8 to retain current behaviour.