### PR TITLE
Add support for docker-compose on debian os

### DIFF
--- a/nova/core/galaxy.yml
+++ b/nova/core/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: nova
 name: core
-version: 3.4.49
+version: 3.4.50
 readme: README.md
 authors:
   - https://github.com/novateams

--- a/nova/core/roles/docker/defaults/main.yml
+++ b/nova/core/roles/docker/defaults/main.yml
@@ -25,3 +25,4 @@ docker_network:
 
 # Docker APT proxy
 docker_apt_proxy: https://download.docker.com/linux/{{ ansible_distribution | lower }}
+docker_use_compose: false

--- a/nova/core/roles/docker/tasks/debian_os.yml
+++ b/nova/core/roles/docker/tasks/debian_os.yml
@@ -136,3 +136,8 @@
           - subnet: "{{ docker_network.ipv4_subnet }}"
           - subnet: "{{ docker_network.ipv6_subnet }}"
       when: not docker_network_check.exists
+
+- name: Install docker-compose python package
+  ansible.builtin.pip:
+    name: docker-compose
+  when: docker_use_compose


### PR DESCRIPTION
Without the docker-compose pip package installed, docker-compose module for Ansible does not work.