### PR TITLE
Process only vSphere compatible interfaces

### DIFF
--- a/nova/core/galaxy.yml
+++ b/nova/core/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: nova
 name: core
-version: 3.18.3
+version: 3.18.4
 readme: README.md
 authors:
   - https://github.com/novateams

--- a/nova/core/roles/configure_networking/tasks/vsphere/main.yml
+++ b/nova/core/roles/configure_networking/tasks/vsphere/main.yml
@@ -27,6 +27,11 @@
       no_log: true
       register: vcenter_session_api_key
 
+    - name: Select vCenter compatible interfaces...
+      ansible.builtin.set_fact:
+        vcenter_interfaces: "{{ interfaces | rejectattr('cloud_id','equalto', '') }}"
+      loop: "{{ interfaces }}"
+
     - name: Including {{ customization_method }} network configuration tasks...
       ansible.builtin.include_tasks: "{{ customization_method }}.yml"
 

--- a/nova/core/roles/configure_networking/tasks/vsphere/networkd.yml
+++ b/nova/core/roles/configure_networking/tasks/vsphere/networkd.yml
@@ -34,7 +34,7 @@
         dest: /tmp/{{ project_fullname | default('') }}_{{ inventory_hostname }}-{{ 10 + interface_index }}-{{ item.network_id }}.network_networkd
         lstrip_blocks: true
         mode: "0644"
-      loop: "{{ interfaces }}"
+      loop: "{{ vcenter_interfaces }}"
       loop_control:
         index_var: interface_index
         label: "{{ item.network_id }}"
@@ -43,7 +43,7 @@
       ansible.builtin.stat:
         path: /tmp/{{ project_fullname | default('') }}_{{ inventory_hostname }}-{{ 10 + interface_index }}-{{ item.network_id }}.network_networkd
       register: network_file_size
-      loop: "{{ interfaces }}"
+      loop: "{{ vcenter_interfaces }}"
       loop_control:
         index_var: interface_index
         label: "{{ item.network_id }}"
@@ -92,7 +92,7 @@
         dest: /tmp/{{ project_fullname | default('') }}_{{ inventory_hostname }}-{{ 10 + interface_index }}-{{ item.network_id }}.link_networkd
         lstrip_blocks: true
         mode: "0644"
-      loop: "{{ interfaces }}"
+      loop: "{{ vcenter_interfaces }}"
       loop_control:
         index_var: interface_index
         label: "{{ item.network_id }}"
@@ -101,7 +101,7 @@
       ansible.builtin.stat:
         path: /tmp/{{ project_fullname | default('') }}_{{ inventory_hostname }}-{{ 10 + interface_index }}-{{ item.network_id }}.link_networkd
       register: link_file_size
-      loop: "{{ interfaces }}"
+      loop: "{{ vcenter_interfaces }}"
       loop_control:
         index_var: interface_index
         label: "{{ item.network_id }}"

--- a/nova/core/roles/machine_operations/tasks/vsphere/create.yml
+++ b/nova/core/roles/machine_operations/tasks/vsphere/create.yml
@@ -213,7 +213,7 @@
     - name: Creating a list of extra NICs...
       ansible.builtin.set_fact:
         extra_network_interfaces: "{{ extra_network_interfaces + [merged] }}"
-      loop: "{{ interfaces[1:] }}"
+      loop: "{{ interfaces[1:] | rejectattr('cloud_id', 'equalto', '') }}"
       loop_control:
         label: "{{ item.cloud_id }}"
       vars:

--- a/nova/core/roles/machine_operations/tasks/vsphere/reconfigure.yml
+++ b/nova/core/roles/machine_operations/tasks/vsphere/reconfigure.yml
@@ -1,3 +1,4 @@
+---
 - name: Reconfiguring existing VM tasks...
   delegate_to: localhost
   become: false


### PR DESCRIPTION
This allows in Providentia to assign 2nd, 3rd etc. interface with virtual IP only. 