### PR TITLE
Added expo_git_branch var 

### DIFF
--- a/nova/core/galaxy.yml
+++ b/nova/core/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: nova
 name: core
-version: 7.4.2
+version: 7.4.3
 readme: README.md
 authors:
   - https://github.com/novateams

--- a/nova/core/roles/expo/defaults/main.yml
+++ b/nova/core/roles/expo/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ### general ###
 expo_git_repo:
+expo_git_branch: main
 expo_fqdn: expo.localhost
 expo_configuration_folder: XS/2023/XS23TR
 expo_project_mode: production

--- a/nova/core/roles/expo/tasks/sync-code.yml
+++ b/nova/core/roles/expo/tasks/sync-code.yml
@@ -23,6 +23,8 @@
     dest: /tmp/expo-{{ fqdn }}
     recursive: true
     depth: 1
+    single_branch: yes
+    version: "{{ expo_git_branch }}"
   delegate_to: localhost
   become: false
 


### PR DESCRIPTION
Added `expo_git_branch` var so that we can specify the branch of expo repo in deployment. 
It helps to reduce my mistake:)